### PR TITLE
[RFR] Parametrize test_create_app & test_source_analysis

### DIFF
--- a/mta/data/analysis.json
+++ b/mta/data/analysis.json
@@ -1,14 +1,18 @@
-{
-  "book-server": {
+[
+  {
+    "app_name": "book-server",
+    "source": "source_code",
     "targets": [
       "cloud-readiness"
     ],
     "story_points": 5
   },
-  "tackle-testapp": {
+  {
+    "app_name": "tackle-testapp",
+    "source": "source_code",
     "targets": [
       "cloud-readiness"
     ],
     "story_points": 1
   }
-}
+]

--- a/mta/data/application.json
+++ b/mta/data/application.json
@@ -1,12 +1,12 @@
-[
-  {
+{
+  "book-server": {
     "name": "book-server",
     "repository": {
       "kind": "git",
       "url": "https://github.com/ibraginsky/book-server"
     }
   },
-  {
+  "tackle-testapp": {
     "name": "tackle-testapp",
     "identities": [],
     "repository": {
@@ -14,5 +14,5 @@
       "url": "https://github.com/konveyor/tackle-testapp"
     }
   }
-]
+}
 

--- a/mta/fixtures/application_inventory.py
+++ b/mta/fixtures/application_inventory.py
@@ -20,7 +20,7 @@ def json_analysis():
         return json.load(file)
 
 
-@pytest.fixture(params=json_analysis(), ids=[f"{item.get('source')}-analysis_item" for item in json_analysis()])
+@pytest.fixture(params=json_analysis(), ids=[item.get("source") for item in json_analysis()])
 def analysis_item(request):
     # Fixture that returns each analysis_item from the list of analysis.json
     return request.param

--- a/mta/fixtures/application_inventory.py
+++ b/mta/fixtures/application_inventory.py
@@ -20,12 +20,6 @@ def json_analysis():
         return json.load(file)
 
 
-@pytest.fixture(params=json_analysis(), ids=[item.get("source") for item in json_analysis()])
-def analysis_item(request):
-    # Fixture that returns each analysis_item from the list of analysis.json
-    return request.param
-
-
 @pytest.fixture(scope="session")
 def application(source_username_credentials, applications_data, create_api, delete_api, request):
     app_name = request.param

--- a/mta/fixtures/application_inventory.py
+++ b/mta/fixtures/application_inventory.py
@@ -3,50 +3,36 @@ import json
 import pytest
 
 from swagger_client.models.api_application import ApiApplication
-from swagger_client.models.api_task import ApiTask
 
 
-@pytest.fixture(scope="session")
 def json_application():
     with open("mta/data/application.json", "r") as file:
-        yield json.load(file)
-
-
-@pytest.fixture(scope="session")
-def analyses_data():
-    with open("mta/data/analysis.json", "r") as file:
         return json.load(file)
 
 
 @pytest.fixture(scope="session")
-def applications(source_username_credentials, json_application, create_api, delete_api):
-    apps = []
-    for app in json_application:
-        application_data = {}
-        for key, value in app.items():
-            application_data[key] = value
-        if "identities" in application_data:
-            application_data["identities"] = [{"id": source_username_credentials.id}]
-        api_app = ApiApplication(**application_data)
-        new_app = create_api.applications_post(api_app.to_dict())
-        apps.append(new_app)
-    yield apps
-    for app in apps:
-        delete_api.applications_id_delete(app.id)
+def applications_data():
+    return json_application()
 
 
-@pytest.fixture()
-def tasks(applications, analyses_data, create_api, get_api, update_api):
-    tasks_from_db = []
-    for app in applications:
-        app_id = app.id
-        app_name = app.name
-        if app_name in analyses_data:
-            analysis_info = analyses_data[app_name]
-            task_data = {"targets": analysis_info["targets"], "output": "/windup/report"}
-            application = {"id": app_id, "name": app_name}
-            task = ApiTask(addon="windup", application=application, data=task_data)
-            new_task = create_api.tasks_post(task=task.to_dict())
-            update_api.tasks_id_submit_put(id=new_task.id, task=new_task)
-            tasks_from_db.append(get_api.tasks_id_get(new_task.id))
-    return tasks_from_db
+def json_analysis():
+    with open("mta/data/analysis.json", "r") as file:
+        return json.load(file)
+
+
+@pytest.fixture(params=json_analysis(), ids=[f"{item.get('source')}-analysis_item" for item in json_analysis()])
+def analysis_item(request):
+    # Fixture that returns each analysis_item from the list of analysis.json
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def application(source_username_credentials, applications_data, create_api, delete_api, request):
+    app_name = request.param
+    app_data = applications_data[app_name]
+    if "identities" in app_data:
+        app_data["identities"] = [{"id": source_username_credentials.id}]
+    api_app = ApiApplication(**app_data)
+    new_app = create_api.applications_post(api_app.to_dict())
+    yield new_app
+    delete_api.applications_id_delete(new_app.id)

--- a/mta/tests/migration/application_inventory/test_analysis.py
+++ b/mta/tests/migration/application_inventory/test_analysis.py
@@ -1,13 +1,24 @@
 import pytest
 from wait_for import wait_for
 
-from mta.fixtures.application_inventory import json_application
+from mta.fixtures.application_inventory import json_analysis, json_application
 from swagger_client.models.api_task import ApiTask
 
 
 @pytest.mark.parametrize("application", json_application(), indirect=True)
+@pytest.mark.parametrize("analysis_item", json_analysis(), ids=[item.get("source") for item in json_analysis()])
 @pytest.mark.analysis
 def test_analysis(application, analysis_item, create_api, get_api, update_api):
+    """
+    This function uses functions to provide input parameters representing an application for analysis and an analysis
+    item to be run on the application. The function starts by checking if the app and analysis item match by comparing
+    their names. If they do not match, the test is skipped.
+
+    If the app and analysis item match, a new task is created for the analysis to be run.
+    The function waits for the task to complete by periodically checking its state until the state changes to
+    "Succeeded".
+    """
+
     app = application
     analysis_info = analysis_item
     if app.name != analysis_info["app_name"]:

--- a/mta/tests/migration/application_inventory/test_analysis.py
+++ b/mta/tests/migration/application_inventory/test_analysis.py
@@ -1,8 +1,21 @@
 import pytest
 from wait_for import wait_for
 
+from mta.fixtures.application_inventory import json_application
+from swagger_client.models.api_task import ApiTask
 
+
+@pytest.mark.parametrize("application", json_application(), indirect=True)
 @pytest.mark.analysis
-def test_source_analysis(tasks, get_api):
-    for task in tasks:
-        wait_for(lambda: get_api.tasks_id_get(str(task.id)).state == "Succeeded", delay=5, timeout=180)
+def test_source_analysis(application, analysis_item, create_api, get_api, update_api):
+    app = application
+    analysis_info = analysis_item
+    if app.name != analysis_info["app_name"]:
+        pytest.skip("The analysis item should not run using the current app. Skipping test")
+    task_data = {"targets": analysis_info["targets"], "output": "/windup/report"}
+    api_task = ApiTask(addon="windup", application={"id": app.id, "name": app.name}, data=task_data)
+    new_task = create_api.tasks_post(task=api_task.to_dict())
+
+    # Start the analysis by calling the submit method
+    update_api.tasks_id_submit_put(id=new_task.id, task=new_task)
+    wait_for(lambda: get_api.tasks_id_get(str(new_task.id)).state == "Succeeded", delay=5, timeout=180)

--- a/mta/tests/migration/application_inventory/test_analysis.py
+++ b/mta/tests/migration/application_inventory/test_analysis.py
@@ -7,7 +7,7 @@ from swagger_client.models.api_task import ApiTask
 
 @pytest.mark.parametrize("application", json_application(), indirect=True)
 @pytest.mark.analysis
-def test_source_analysis(application, analysis_item, create_api, get_api, update_api):
+def test_analysis(application, analysis_item, create_api, get_api, update_api):
     app = application
     analysis_info = analysis_item
     if app.name != analysis_info["app_name"]:

--- a/mta/tests/migration/application_inventory/test_application.py
+++ b/mta/tests/migration/application_inventory/test_application.py
@@ -1,8 +1,10 @@
 import pytest
 
+from mta.fixtures.application_inventory import json_application
 
+
+@pytest.mark.parametrize("application", json_application(), indirect=True)
 @pytest.mark.app
-def test_create_app(applications, get_api):
-    for app in applications:
-        app_from_db = get_api.applications_id_get(app.id)
-        assert app.name == app_from_db.name
+def test_create_app(application, get_api):
+    app_from_db = get_api.applications_id_get(application.id)
+    assert application.name == app_from_db.name


### PR DESCRIPTION
Output:
```
$ python3 -m pytest -v --tc-file=config.json --tc-format=json -m "app or analysis"
============================= test session starts ==============================

platform linux -- Python 3.10.8, pytest-7.1.2, pluggy-1.0.0 -- /home/fedora/.local/share/virtualenvs/tackle-api-tests-pr-tester_PR-46-qnD4Ltl4/bin/python

cachedir: .pytest_cache

rootdir: /home/fedora/workspace/tackle-api-tests-pr-tester_PR-46, configfile: pytest.ini

plugins: testconfig-0.2.0, check-1.3.0

collecting ... collected 6 items



mta/tests/migration/application_inventory/test_analysis.py::test_source_analysis[source_code_analysis_item0-book-server] PASSED [ 16%]

mta/tests/migration/application_inventory/test_analysis.py::test_source_analysis[source_code_analysis_item1-book-server] SKIPPED [ 33%]

mta/tests/migration/application_inventory/test_application.py::test_create_app[book-server] PASSED [ 50%]

mta/tests/migration/application_inventory/test_analysis.py::test_source_analysis[source_code_analysis_item0-tackle-testapp] SKIPPED [ 66%]

mta/tests/migration/application_inventory/test_analysis.py::test_source_analysis[source_code_analysis_item1-tackle-testapp] PASSED [ 83%]

mta/tests/migration/application_inventory/test_application.py::test_create_app[tackle-testapp] PASSED [100%]



=================== 4 passed, 2 skipped in 301.49s (0:05:01) ===================
```